### PR TITLE
Add cosmic-comp (standalone)

### DIFF
--- a/startlxqtwayland.in
+++ b/startlxqtwayland.in
@@ -7,6 +7,14 @@ contains()
     [ "$str" = "$substr" -o -z "${str##$substr:*}" -o -z "${str##*:$substr:*}" -o -z "${str%%*:$substr}" ]
 }
 
+wayland_library() {
+    case $COMPOSITOR in
+        cosmic-comp) echo 'smithay' ;;
+        *) echo 'wlroots' ;;
+    esac
+}
+
+
 if [ -z "$XDG_DATA_HOME" ]; then
     export XDG_DATA_HOME="$HOME/.local/share"
 fi
@@ -73,7 +81,7 @@ if grep -q "compositor" "$XDG_CONFIG_HOME/lxqt/session.conf"; then
     COMPOSITOR=`cat "$XDG_CONFIG_HOME"/lxqt/session.conf|grep compositor |awk -F'=' '{print $2}'`
 fi
 
-export XDG_CURRENT_DESKTOP="LXQt:$COMPOSITOR:wlroots"
+export XDG_CURRENT_DESKTOP="LXQt:$COMPOSITOR:$(wayland_library)"
 
 export MOZ_ENABLE_WAYLAND=1
 

--- a/startlxqtwayland.in
+++ b/startlxqtwayland.in
@@ -182,10 +182,10 @@ elif [ "$COMPOSITOR" = "river" ]; then
     fi
     exec river -c $XDG_CONFIG_HOME/lxqt/wayland/lxqt-river-init
 
-elif [ "$COMPOSITOR" = "cosmic-comp" ]; then
+# elif [ "$COMPOSITOR" = "cosmic-comp" ]; then
     # NOTE: Cosmic compositor creates default configurations on first start
     #       which are located at $XDG_CONFIG_HOME/cosmic
-    exec cosmic-comp
+    # exec cosmic-comp
 
 # unknown compositor
 else

--- a/startlxqtwayland.in
+++ b/startlxqtwayland.in
@@ -182,6 +182,11 @@ elif [ "$COMPOSITOR" = "river" ]; then
     fi
     exec river -c $XDG_CONFIG_HOME/lxqt/wayland/lxqt-river-init
 
+elif [ "$COMPOSITOR" = "cosmic-comp" ]; then
+    # NOTE: Cosmic compositor creates default configurations on first start
+    #       which are located at $XDG_CONFIG_HOME/cosmic
+    exec cosmic-comp
+
 # unknown compositor
 else
     echo "Trying to start $COMPOSITOR..."


### PR DESCRIPTION
Minimal integration of the Cosmic compositor (`cosmic-comp` package).

**Notes:**
It helps to install `cosmic-launcher` (pendant to `lxqt-runner`) and `cosmic-settings-daemon` (creates default configuration files in `$XDG_CONFIG_HOME/cosmic`). Pressing `Super` key should open a text input to spawn applications (press twice after startup).
