### PR TITLE
startlxqtwayland: Correctly identify Niri and Hyprland

### DIFF
--- a/startlxqtwayland.in
+++ b/startlxqtwayland.in
@@ -112,6 +112,7 @@ elif [ "$COMPOSITOR" = "labwc" ]; then
     exec $COMPOSITOR -C $XDG_CONFIG_HOME/labwc -S lxqt-session
 
 elif [ "$COMPOSITOR" = "niri" ]; then
+    export XDG_CURRENT_DESKTOP="LXQt:$COMPOSITOR:smithay"
     if [ ! -f "$XDG_CONFIG_HOME/lxqt/wayland/lxqt-niri.kdl" ]; then
         cp -v "$share_dir"/lxqt/wayland/lxqt-niri.kdl "$XDG_CONFIG_HOME"/lxqt/wayland/
         if echo "$valid_layouts" | grep -q "$trylayout"; then
@@ -163,6 +164,7 @@ elif [ "$COMPOSITOR" = "sway" ]; then
     exec $COMPOSITOR -c $XDG_CONFIG_HOME/lxqt/wayland/lxqt-sway.config
 
 elif [ "$COMPOSITOR" = "Hyprland" ]; then
+    export XDG_CURRENT_DESKTOP="LXQt:$COMPOSITOR"
     if [ ! -f "$XDG_CONFIG_HOME/lxqt/wayland/lxqt-hyprland.conf" ]; then
         cp "$share_dir"/lxqt/wayland/lxqt-hyprland.conf "$XDG_CONFIG_HOME"/lxqt/wayland/
         if echo "$valid_layouts" | grep -q "$trylayout"; then


### PR DESCRIPTION
Niri is not a member of wlroots (it uses Smithay) and Hyprland is a completely independent compositor (it no longer uses wlroots).