### PR TITLE
Fix for full path of compositors

### DIFF
--- a/startlxqtwayland.in
+++ b/startlxqtwayland.in
@@ -70,7 +70,7 @@ if [ ! -d "$XDG_CONFIG_HOME/lxqt/wayland" ]; then
 fi
 
 if grep -q "compositor" "$XDG_CONFIG_HOME/lxqt/session.conf"; then
-    COMPOSITOR=`cat "$XDG_CONFIG_HOME"/lxqt/session.conf|grep compositor |awk -F'=' '{print $2}'`
+    COMPOSITOR=`cat "$XDG_CONFIG_HOME"/lxqt/session.conf|grep compositor |awk -F'=' '{sub(".*/", "", $2); print $2}'`
 fi
 
 export XDG_CURRENT_DESKTOP="LXQt:$COMPOSITOR:wlroots"


### PR DESCRIPTION
Fixes https://github.com/lxqt/lxqt-wayland-session/issues/43

Another option would be using ` sed 's|.*=\(.*/\)\?\(.*\)|\2|'`, anyway I've some suspect that it could be more optimized:

```
if grep -q "compositor" "$XDG_CONFIG_HOME/lxqt/session.conf"; then
    COMPOSITOR=`cat "$XDG_CONFIG_HOME"/lxqt/session.conf|grep compositor |awk -F'=' '{sub(".*/", "", $2); print $2}'`
fi
```