### PR TITLE
Support default compositor and screenlocker

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,14 @@ display managers and default configurations for actually supported compositors w
   
 At startup a basic configuration file for those compositors will be copied to `$XDG_CONFIG_HOME/lxqt/wayland` directory
 if not existing already, except for labwc and `kwin_wayland` where their default configuration location is used.
-If no compositor is already set in `lxqt-config-session` Labwc will be started opening "Session Settings".
+If no compositor is set in `lxqt-config-session` the default configuration in `/usr/share/lxqt/session.conf` or `/usr/locale/share/lxqt/session.conf` will be used to configure the session, example:
+```
+[General]
+leave_confirmation=true
+compositor=labwc
+lock_command_wayland=swaylock
+```
+If no compositor is found starting Labwc will be tried, opening "Session Settings"
 
 Please refer to each compositors documentation for tweaking.
 

--- a/startlxqtwayland.in
+++ b/startlxqtwayland.in
@@ -75,7 +75,7 @@ if grep -q "compositor" "$share_dir/lxqt/session.conf"; then
     default_compositor=$(cat $share_dir/lxqt/session.conf|grep compositor)
     default_screenlocker=$(cat $share_dir/lxqt/session.conf|grep lock_command_wayland)
     if [ ! -f "$XDG_CONFIG_HOME/lxqt/session.conf" ]; then
-        cp -a $share_dir/lxqt/ $XDG_CONFIG_HOME/
+        cp $share_dir/lxqt/session.conf $XDG_CONFIG_HOME/lxqt/session.conf
     else
         config_file="$XDG_CONFIG_HOME/lxqt/session.conf"
         if ! grep -q "compositor" "$XDG_CONFIG_HOME/lxqt/session.conf"; then

--- a/startlxqtwayland.in
+++ b/startlxqtwayland.in
@@ -65,8 +65,26 @@ export QT_ACCESSIBILITY=1
 # use lxqt-applications.menu for main app menu
 export XDG_MENU_PREFIX="lxqt-"
 
+share_dir="$(dirname $(dirname "$0"))"/share
+
 if [ ! -d "$XDG_CONFIG_HOME/lxqt/wayland" ]; then
     mkdir -p $XDG_CONFIG_HOME/lxqt/wayland/
+fi
+# Check for default compositor set by distro
+if grep -q "compositor" "$share_dir/lxqt/session.conf"; then
+	echo Default Wayland compositor configured
+	default_compositor=$(cat $share_dir/lxqt/session.conf|grep compositor)
+    if [ ! -f "$XDG_CONFIG_HOME/lxqt/session.conf" ]; then
+    	echo "No LXQt Settings found"
+    	cp -a $share_dir/lxqt/ $XDG_CONFIG_HOME/
+    else
+    	echo lxqt-session-configured
+    	if ! grep -q "compositor" "$XDG_CONFIG_HOME/lxqt/session.conf"; then
+        # file exists and doesn not contain "compositor"
+		config_file="$XDG_CONFIG_HOME/lxqt/session.conf"
+        sed -i '/^\[General\]/a '"$default_compositor" "$config_file"
+		fi
+	fi
 fi
 
 if grep -q "compositor" "$XDG_CONFIG_HOME/lxqt/session.conf"; then
@@ -76,8 +94,6 @@ fi
 export XDG_CURRENT_DESKTOP="LXQt:$COMPOSITOR:wlroots"
 
 export MOZ_ENABLE_WAYLAND=1
-
-share_dir="$(dirname $(dirname "$0"))"/share
 
 valid_layouts=$(grep -A98 '! layout' /usr/share/X11/xkb/rules/base.lst | awk '{print $1}' | grep -v '!')
 trylayout=$(echo $LANG | cut -c 1,2)

--- a/startlxqtwayland.in
+++ b/startlxqtwayland.in
@@ -70,21 +70,23 @@ share_dir="$(dirname $(dirname "$0"))"/share
 if [ ! -d "$XDG_CONFIG_HOME/lxqt/wayland" ]; then
     mkdir -p $XDG_CONFIG_HOME/lxqt/wayland/
 fi
-# Check for default compositor set by distro
+# Check for default compositor and screenlocker eventually set by distribution
 if grep -q "compositor" "$share_dir/lxqt/session.conf"; then
-	echo Default Wayland compositor configured
-	default_compositor=$(cat $share_dir/lxqt/session.conf|grep compositor)
+    default_compositor=$(cat $share_dir/lxqt/session.conf|grep compositor)
+    default_screenlocker=$(cat $share_dir/lxqt/session.conf|grep lock_command_wayland)
     if [ ! -f "$XDG_CONFIG_HOME/lxqt/session.conf" ]; then
-    	echo "No LXQt Settings found"
-    	cp -a $share_dir/lxqt/ $XDG_CONFIG_HOME/
+        cp -a $share_dir/lxqt/ $XDG_CONFIG_HOME/
     else
-    	echo lxqt-session-configured
-    	if ! grep -q "compositor" "$XDG_CONFIG_HOME/lxqt/session.conf"; then
-        # file exists and doesn not contain "compositor"
-		config_file="$XDG_CONFIG_HOME/lxqt/session.conf"
-        sed -i '/^\[General\]/a '"$default_compositor" "$config_file"
-		fi
-	fi
+        config_file="$XDG_CONFIG_HOME/lxqt/session.conf"
+        if ! grep -q "compositor" "$XDG_CONFIG_HOME/lxqt/session.conf"; then
+            # file exists and does not contain "compositor"
+            sed -i '/^\[General\]/a '"$default_compositor" "$config_file"
+        fi
+        if ! grep -q "lock_command_wayland" "$XDG_CONFIG_HOME/lxqt/session.conf"; then
+            # file exists and does not contain "screenlocker"
+            sed -i '/^\[General\]/a '"$default_screenlocker" "$config_file"
+        fi
+    fi
 fi
 
 if grep -q "compositor" "$XDG_CONFIG_HOME/lxqt/session.conf"; then


### PR DESCRIPTION
Replacement for https://github.com/lxqt/lxqt-wayland-session/pull/58
Needs more testing, and probably @palinek could simplify it more.
If no `session.conf` is found it works also for the screenlocker, for other cases it has to added to the script.