### PR TITLE
Make sue XDG_SESSION_TYPE=wayland is set when starting from tty

### DIFF
--- a/startlxqtwayland.in
+++ b/startlxqtwayland.in
@@ -65,6 +65,9 @@ export QT_ACCESSIBILITY=1
 # use lxqt-applications.menu for main app menu
 export XDG_MENU_PREFIX="lxqt-"
 
+# Ensure this is set always
+export XDG_SESSION_TYPE="wayland"
+
 share_dir="$(dirname $(dirname "$0"))"/share
 
 if [ ! -d "$XDG_CONFIG_HOME/lxqt/wayland" ]; then


### PR DESCRIPTION
Both kwin_wayland and niri don't set this (`niri-session` does) by themselves. 
So if `startlxqtwayland` is executed with either one of the above
a) from tty
b) using autologin with `greetd` and `tuigreet`
we have ` XDG_SESSION_TYPE=tty`.

By chance this didn't have effects (we check in the panel for `xcb` and otherwise "it's wayland"), at least I didn't notice them.

If using greetd with its interface it's set.
