### PR TITLE
Added shortcut for showdesktop and fancymenu for labwc

### DIFF
--- a/configurations/labwc/rc.xml
+++ b/configurations/labwc/rc.xml
@@ -286,6 +286,13 @@
         <command>lxqt-leave</command>
       </action>
     </keybind>
+    <keybind key="W-d">
+      <action name="Execute" command="qdbus6 org.kde.StatusNotifierWatcher /global_key_shortcuts/panel/showdesktop/show_hide org.lxqt.global_key_shortcuts.client.activated" />
+    </keybind>
+    <keybind key="A-F1">
+      <action name="Execute" command="qdbus6 org.kde.StatusNotifierWatcher /global_key_shortcuts/panel/fancymenu/show_hide org.lxqt.global_key_shortcuts.client.activated" />
+    </keybind>
+    <!-- End LXQt Keybindings -->
     <keybind key="A-Tab">
       <action name="NextWindow" />
     </keybind>

--- a/configurations/lxqt-wayfire.ini
+++ b/configurations/lxqt-wayfire.ini
@@ -190,7 +190,7 @@ command_logout = lxqt-leave --logout
 
 # Open Fancy Applications Menu
 binding_menu = <alt> KEY_F1
-command_menu = qdbus org.kde.StatusNotifierWatcher /global_key_shortcuts/panel/fancymenu/show_hide org.lxqt.global_key_shortcuts.client.activated
+command_menu = qdbus6 org.kde.StatusNotifierWatcher /global_key_shortcuts/panel/fancymenu/show_hide org.lxqt.global_key_shortcuts.client.activated
 
 # Screenshots
 binding_screenshot = KEY_PRINT | KEY_SYSRQ


### PR DESCRIPTION
It works only after the mouse has already been over the panel once after login.

Also, use the Qt6 variant of the QDBus tool for wayfire.