### PR TITLE
Set XDG_CURRENT_DESKTOP for new units started by user service manager

### DIFF
--- a/startlxqtwayland.in
+++ b/startlxqtwayland.in
@@ -83,6 +83,11 @@ done
 
 export XDG_CURRENT_DESKTOP="LXQt:$COMPOSITOR:wlroots"
 
+# set environment variables for new units started by user service manager
+if command -v systemctl >/dev/null; then
+    systemctl --user import-environment XDG_CURRENT_DESKTOP
+fi
+
 valid_layouts=$(grep -A98 '! layout' /usr/share/X11/xkb/rules/base.lst | awk '{print $1}' | grep -v '!')
 trylayout=$(echo $LANG | cut -c 1,2)
 
@@ -90,6 +95,11 @@ if  [ -z "$COMPOSITOR" ]; then
     echo "No compositor configured yet in Session Settings, trying labwc..."
     COMPOSITOR=labwc
     export XDG_CURRENT_DESKTOP="LXQt:wlroots"
+
+    # set environment variables for new units started by user service manager
+    if command -v systemctl >/dev/null; then
+        systemctl --user import-environment XDG_CURRENT_DESKTOP
+    fi
 
     # enable cursor on VM (systemd only)
     if type systemd-detect-virt > /dev/null 2>&1 && systemd-detect-virt --quiet; then
@@ -125,6 +135,12 @@ elif [ "$COMPOSITOR" = "kwin_wayland" ]; then
     # Style KDE's QML apps like systemsettings
     export QT_QUICK_CONTROLS_STYLE=org.kde.desktop
     export XDG_CURRENT_DESKTOP="LXQt:$COMPOSITOR"
+
+    # set environment variables for new units started by user service manager
+    if command -v systemctl >/dev/null; then
+        systemctl --user import-environment XDG_CURRENT_DESKTOP
+    fi
+
     if echo "$valid_layouts" | grep -q "$trylayout"; then
         kxkbrc=$XDG_CONFIG_HOME/kxkbrc
         layout="LayoutList=$trylayout"


### PR DESCRIPTION
This fixes the problem that XDG Desktop Portal does not use the LXQt backend under LXQt session.

Corresponding pull request for lxqt-session: https://github.com/lxqt/lxqt-session/pull/605