### PR TITLE
start: Use character classes in sed, fix for freeBSD

### DIFF
--- a/startlxqtwayland.in
+++ b/startlxqtwayland.in
@@ -77,7 +77,7 @@ fi
 for d in $(echo "$XDG_CONFIG_HOME:$XDG_CONFIG_DIRS" | tr : '\n'); do
     config_file="$d/lxqt/session.conf"
     [ -f "$config_file" ] && [ -r "$config_file" ] || continue
-    COMPOSITOR="$(sed -nre '/^compositor\s*=/ { s@^[^=]+=\s*(/|\S+.*/)?([^/]+)?$@\2@; p; }' "$config_file")"
+    COMPOSITOR="$(sed -nre '/^compositor[[:space:]]*=/ { s@^[^=]+=[[:space:]]*(/|[^[:space:]]+.*/)?([^/]+)?$@\2@; p; }' "$config_file")"
     [ -z "$COMPOSITOR" ] || break
 done
 


### PR DESCRIPTION
Fixes #92 