### PR TITLE
Robuster search:  look first for desktop name.

### DIFF
--- a/lxqt-qdbus.in
+++ b/lxqt-qdbus.in
@@ -45,13 +45,6 @@ if [[ ! " ${valid[*]} " =~ " $1 " ]]; then
     exit 1
 fi
 
-valid=("up" "down" "mute" {1..10})
-if [[ ! " ${valid[*]} " =~ " $2 " ]]; then
-    echo "Invalid option: '$2'"
-    print_help
-    exit 1
-fi
-
 MODE=$1
 # argument: <application> | [1-10] | up , down, mute
 ARGUMENT=$2


### PR DESCRIPTION
Previously some .desktop files like `firefox.desktop` or `chromium.desktop` produced errors. Now
1.`lxqt-qdbus run name`  looks for `<name>.desktop` in `$XDG_DATA_DIRS/applications`
2. If no direct match is found it searches the `Exec=` lines.