### PR TITLE
labwc: Add keybind for qlipper

### DIFF
--- a/configurations/labwc/rc.xml
+++ b/configurations/labwc/rc.xml
@@ -707,6 +707,11 @@
       </windowRule>
     </windowRules>
   -->
+  <windowRules>
+    <windowRule identifier="qlipper" title="* - *" skipTaskbar="yes">
+      <action name="SetDecorations" decorations="none"/>
+    </windowRule>
+  </windowRules>
 
   <menu>
     <ignoreButtonReleasePeriod>250</ignoreButtonReleasePeriod>


### PR DESCRIPTION
Note: the qlipper is now fully usable also in waylad, as the menu (shorcut activation) can now be invoked via dbus. So it is easy to configure the shorcut in e.g. labwc
```xml
    <keybind key="C-S-v">
      <action name="Execute" command="qdbus6 org.qlipper /org/qlipper show" />
    </keybind>
```