### PR TITLE
lxqt-qdbus: Added method to restart lxqt-modules.

### DIFF
--- a/lxqt-qdbus.in
+++ b/lxqt-qdbus.in
@@ -11,6 +11,9 @@ Options:
   run <application>     Start an application inside lxqt-session
   openmenu              Open Fancy Menu
   showdesktop           Show desktop on stacking WMs
+  restart [module]      Restart a lxqt-module
+                        Main modules: desktop, panel, runner, notifications,
+                        powermanagement, policykit-agent
   task [1-10]           Focus Window <number on taskbar>
   volume [up|down|mute] Change volume in volume plugin
   -h, --help            Show this help message and exit
@@ -24,7 +27,7 @@ case "$1" in
         exit 0
         ;;
       -v|--version)
-        echo "${0##*/} version 0.1"
+        echo "${0##*/} version 0.2"
         exit 0
         ;;
     *)
@@ -38,7 +41,7 @@ if [[ -z "${QDBUS:-}" ]]; then
     exit 1
 fi
 
-valid=("run" "openmenu" "showdesktop" "task" "volume")
+valid=("run" "openmenu" "showdesktop" "restart" "task" "volume")
 if [[ ! " ${valid[*]} " =~ " $1 " ]]; then
     echo "Invalid argument: $1"
     print_help
@@ -46,7 +49,7 @@ if [[ ! " ${valid[*]} " =~ " $1 " ]]; then
 fi
 
 MODE=$1
-# argument: <application> | [1-10] | up , down, mute
+# argument: <application> | module | [1-10] | up , down, mute
 ARGUMENT=$2
 
 if [ "$MODE" = "run" ]; then
@@ -62,6 +65,7 @@ if [ "$MODE" = "run" ]; then
         notify-send -i configure-shortcuts -a "LXQt Wayland Shortcut" "No matching desktop entry found for '$ARGUMENT'"
         exit 1
     fi
+
 elif  [ "$MODE" = "openmenu" ]; then # open main|fancy menu
     # check for dbus object
     menu=$($QDBUS org.kde.StatusNotifierWatcher | grep -E '(fancy|main)menu' | head -n1)
@@ -70,6 +74,7 @@ elif  [ "$MODE" = "openmenu" ]; then # open main|fancy menu
     else
     $QDBUS org.kde.StatusNotifierWatcher $menu/show_hide org.lxqt.global_key_shortcuts.client.activated
     fi
+
 elif  [ "$MODE" = "showdesktop" ]; then # show desktop
     # check for dbus object
     showdesktop=$($QDBUS org.kde.StatusNotifierWatcher | grep showdesktop | head -n1)
@@ -78,6 +83,18 @@ elif  [ "$MODE" = "showdesktop" ]; then # show desktop
     else
         $QDBUS org.kde.StatusNotifierWatcher $showdesktop/show_hide org.lxqt.global_key_shortcuts.client.activated
     fi
+
+elif  [ "$MODE" = "restart" ]; then # restart <module>
+    # check for dbus object
+    modules=$($QDBUS org.lxqt.session /LXQtSession org.lxqt.session.listModules | grep lxqt-$2.desktop)
+    if [[ -z "$modules" ]]; then
+        notify-send --icon=lxqt "Module lxqt-$2 not found"
+    else
+        $QDBUS org.lxqt.session /LXQtSession org.lxqt.session.stopModule lxqt-"$2".desktop;
+        sleep 1;
+        $QDBUS org.lxqt.session /LXQtSession org.lxqt.session.startModule lxqt-"$2".desktop;
+    fi
+
 elif  [ "$MODE" = "task" ]; then # activate taskbar button
     # check for dbus object
     taskbar=$($QDBUS org.kde.StatusNotifierWatcher | grep taskbar | head -n1)
@@ -86,6 +103,7 @@ elif  [ "$MODE" = "task" ]; then # activate taskbar button
     else
         $QDBUS org.kde.StatusNotifierWatcher $taskbar/task_$2 org.lxqt.global_key_shortcuts.client.activated
     fi
+
 elif  [ "$MODE" = "volume" ]; then
     # check for dbus object
     volume=$($QDBUS org.kde.StatusNotifierWatcher | grep volume | head -n1)


### PR DESCRIPTION
May be useful when using kanshi for example.